### PR TITLE
fix: WebGL初期化失敗でアプリ全体がクラッシュする問題とreduced-motion時の背景消失を修正

### DIFF
--- a/components/backgrounds/neon-particles.tsx
+++ b/components/backgrounds/neon-particles.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef } from "react";
 import { Renderer, Camera, Geometry, Program, Mesh } from "ogl";
+import { debugError } from "@/lib/utils";
 
 interface ParticlesProps {
   particleCount?: number;
@@ -114,17 +115,30 @@ const Particles: React.FC<ParticlesProps> = ({
     const container = containerRef.current;
     if (!container) return;
 
-    // Check if prefers-reduced-motion is set - do not start animation if true
+    // Check if prefers-reduced-motion is set - if so, render a static starfield
+    // instead of a fully animated one (autonomous motion is frozen further below,
+    // but mouse-follow interaction and rendering still happen).
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (prefersReducedMotion) {
+
+    let renderer: Renderer;
+    let gl: Renderer["gl"];
+    try {
+      // WebGL context creation can throw or fail to attach a valid renderer
+      // (e.g. GPU acceleration disabled, remote desktop, headless browsers).
+      // This component is purely decorative, so any failure here must not
+      // propagate and take down the rest of the React tree.
+      renderer = new Renderer({ depth: false, alpha: true });
+      gl = renderer.gl;
+      if (!gl) {
+        throw new Error("WebGL context is unavailable");
+      }
+      gl.canvas.setAttribute('aria-hidden', 'true');
+      container.appendChild(gl.canvas);
+      gl.clearColor(0, 0, 0, 0);
+    } catch (error) {
+      debugError('WebGL unavailable, skipping particle background:', error);
       return;
     }
-
-    const renderer = new Renderer({ depth: false, alpha: true });
-    const gl = renderer.gl;
-    gl.canvas.setAttribute('aria-hidden', 'true');
-    container.appendChild(gl.canvas);
-    gl.clearColor(0, 0, 0, 0);
 
     const camera = new Camera(gl, { fov: 15 });
     camera.position.set(0, 0, cameraDistance);
@@ -208,7 +222,12 @@ const Particles: React.FC<ParticlesProps> = ({
       }
 
       lastTime = t;
-      elapsed += delta * speed;
+
+      // Under reduced motion, freeze autonomous animation (time stays at 0 and
+      // rotation is skipped) while still rendering a static frame each tick.
+      if (!prefersReducedMotion) {
+        elapsed += delta * speed;
+      }
 
       program.uniforms.uTime.value = elapsed * 0.001;
 
@@ -220,7 +239,7 @@ const Particles: React.FC<ParticlesProps> = ({
         particles.position.y = 0;
       }
 
-      if (!disableRotation) {
+      if (!prefersReducedMotion && !disableRotation) {
         particles.rotation.x = Math.sin(elapsed * 0.0002) * 0.1;
         particles.rotation.y = Math.cos(elapsed * 0.0005) * 0.15;
         particles.rotation.z += 0.01 * speed;


### PR DESCRIPTION
## 症状(本番で報告)

1. 宇宙的な背景のマウス追従が消えた
2. チャットボットのボタンが表示されない

## 根本原因

ブラウザでWebGLコンテキストの作成に失敗すると(GPUアクセラレーション無効・リモートデスクトップ等)、`neon-particles.tsx` の `new Renderer()` が未捕捉例外 `Cannot set properties of null (setting 'renderer')` を投げ、**Reactクライアントツリー全体がアンマウント**される。装飾用の背景コンポーネントがチャットボタンを含む全インタラクティブ要素を道連れにしていた(例外パス自体は以前から存在したが無ガード)。

副次的に、`prefers-reduced-motion` 有効時は静止フレームを表示すべきところ、初期化ごと skip して背景が完全に消えていた。

## 修正

- WebGL初期化を try/catch + nullチェックでガードし、失敗時は `debugError` してコンポーネントだけ静かに諦める(アプリ本体は無傷)
- reduced-motion時: レンダリング自体は行い、自律的モーション(時間経過・回転)のみ凍結。**マウス追従はユーザー起点のモーションのため維持**

## 検証(本番ビルドで3シナリオ、Playwright)

| シナリオ | 結果 |
|---|---|
| WebGL無効 | クラッシュなし・チャットボタン表示(背景のみ非表示) |
| WebGL有効+通常 | 星空描画・マウス追従・チャットボタンすべて正常 |
| WebGL有効+reduced-motion | 静止した星空を表示・マウス追従維持・チャットボタン表示 |

lint / typecheck 通過。

## 報告者向けの確認方法

マージ後もマウス追従が見えない場合、お使いのブラウザでWebGLが無効になっている可能性があります: `chrome://gpu` を開き「WebGL: Hardware accelerated」になっているかご確認ください(その場合も本修正によりチャットボタンは表示されるようになります)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)